### PR TITLE
fix: 🐛 change asgiref version to fix installation error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asgiref==3.7.2
+asgiref>=3.6.0,<4
 async-timeout==4.0.3
 attrs==24.2.0
 autobahn==24.4.2


### PR DESCRIPTION
## 🔨 What this Pull Request does?

This Pull Request changes the asgiref version to fix an installation error.

## 📸  PrintScreen's and explanation:

When I went to install the project, running pip on my macOS machine, I received this installation error with inconsistency of the asgiref library in relation to the other libraries in the project, as you can see in the screenshot below.

![InstallationErrorPythonProject](https://github.com/user-attachments/assets/3c286df8-41d9-40df-9570-ec4df479444c)


When changing the version, the error was resolved and the installation was successful, as you can see in the second screenshot:

![ResultAfterChange](https://github.com/user-attachments/assets/2d68cfc0-4080-47c6-89b8-9c0cc9acea47)


## 🧐 Change type

- [ ] ✨ **Minor**: New functionality, without breaking compatibility with previous versions.
- [x] 🐛 **Fix**: Fix a bug/problem inside the project.

### 🧪 Tests

This change did not require any unit testing.